### PR TITLE
Controls & tooltips z-index.

### DIFF
--- a/dist/svgMap.css
+++ b/dist/svgMap.css
@@ -27,7 +27,7 @@
   position: absolute;
   bottom: 10px;
   left: 10px;
-  z-index: 50;
+  z-index: 1;
   display: flex;
   overflow: hidden;
   border-radius: 2px;
@@ -102,7 +102,7 @@
 .svgMap-tooltip {
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.2);
   position: absolute;
-  z-index: 10000;
+  z-index: 2;
   border-radius: 2px;
   background: #fff;
   transform: translate(-50%, -100%);

--- a/src/scss/map.scss
+++ b/src/scss/map.scss
@@ -27,7 +27,7 @@
     position: absolute;
     bottom: 10px;
     left: 10px;
-    z-index: 50;
+    z-index: 1;
     display: flex;
     overflow: hidden;
     border-radius: 2px;

--- a/src/scss/tooltip.scss
+++ b/src/scss/tooltip.scss
@@ -1,7 +1,7 @@
 .svgMap-tooltip {
   box-shadow: 0 0 3px rgba(0, 0, 0, .2);
   position: absolute;
-  z-index: 10000;
+  z-index: 2;
   border-radius: 2px;
   background: #fff;
   transform: translate(-50%, -100%);


### PR DESCRIPTION
Since no other element have a z-index defined, 0 is considered for all elements.

Having z-index 50 for the map controls and z-index 10000 for the tooltips can create overlay issues in several cases.

I'm suggesting z-index 1 for map controls, and z-index 2 for tooltips.

This should avoid lots of issues with Boostrap and other CSS framework implementations, as they generally have higher z-index values defined.

A clear example where z-index 50 for map controls is too high, is on a layout that has, let's say... a "slide-over" menu, with a z-index less than that, the map controls would actually overlay that menu, which is really undesirable. Or the tooltip would overlay the primary navigation element (let's say the header), no element on a page should supersed that.

I have already done the required tests to ensure that it still works as expected, tooltips will overlay everything, and the map controls will overlay the map elements.