### PR TITLE
Prevent firing click when dragging.

### DIFF
--- a/src/js/svgMap.js
+++ b/src/js/svgMap.js
@@ -844,7 +844,17 @@ function svgMapWrapper(svgPanZoom) {
               this.options.data.values[countryID]['linkTarget']
             );
           }
-          countryElement.addEventListener('click', function (e) {
+
+          let dragged = false;
+          countryElement.addEventListener('mousedown', function(){dragged = false});
+          countryElement.addEventListener('touchstart', function(){dragged = false});
+          countryElement.addEventListener('mousemove', function(){dragged = true});
+          countryElement.addEventListener('touchmove', function(){dragged = true});
+          const clickHandler = function (e) {
+            if (dragged) {
+                return;
+            }
+
             const link = countryElement.getAttribute('data-link');
             const target = countryElement.getAttribute('data-link-target');
 
@@ -853,7 +863,10 @@ function svgMapWrapper(svgPanZoom) {
             } else {
               window.location.href = link;
             }
-          });
+          }
+
+          countryElement.addEventListener('click', clickHandler);
+          countryElement.addEventListener('touchend', clickHandler);
         }
 
         // Hide tooltip when mouse leaves the country area


### PR DESCRIPTION
Currently, when trying to pan the map and mouse cursor is on any country, click event will be triggered after panning, URL will be changed (if data link is set). This seems limiting how you can pan the map.

This PR will prevent click from firing by logging if mouse (or finger) has been moved before mouse button / finger press is released.

And also, thank you for the great project!