### PR TITLE
Improve customizability with more variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ You can overwrite the following scss variables to customize the style of the map
 | $countryStrokeColor             | #fff                         |
 ---
 
-
 ## Localize
 
 Use the option `countryNames` to translate country names. In the folder `demo/html/local` or `demo/es6/local` you can find translations in following languages: Arabic, Chinese, English, French, German, Hindi, Portuguese, Russian, Spanish, Urdu.

--- a/README.md
+++ b/README.md
@@ -74,45 +74,69 @@ https://stephanwagner.me/create-world-map-charts-with-svgmap#svgMapDemoGDP
 
 You can pass the following options into svgMap:
 
-| Option      | Type | Default |  |
-| --- | --- | --- | --- |
-| `targetElementID` | `string` | | The ID of the element where the world map will render (Required) |
-| `minZoom` | `float` | `1` | Minimal zoom level |
-| `maxZoom` | `float` | `25` | Maximal zoom level |
-| `initialZoom` | `float` | `1.06` | Initial zoom level |
-| `initialPan` | `object` | | Initial pan on x and y axis (e.g. `{ x: 30, y: 60 }`) |
-| `showContinentSelector` | `boolean` | `false` | Show continent selector |
-| `zoomScaleSensitivity` | `float` | `0.2` | Sensitivity when zooming |
-| `showZoomReset` | `boolean` | `false` | Show zoom reset button |
-| `mouseWheelZoomEnabled` | `boolean` | `true` | Enables or disables zooming with the scroll wheel |
-| `mouseWheelZoomWithKey` | `boolean` | `false` | Allow zooming only when one of the following keys is pressed: SHIFT, CONTROL, ALT, COMMAND, OPTION |
-| `mouseWheelKeyMessage` | `string` | `'Press the [ALT] key to zoom'` | The message when trying to scroll without a key |
-| `mouseWheelKeyMessageMac` | `string ` | `Press the [COMMAND] key to zoom` | The message when trying to scroll without a key on MacOS |
-| `colorMax` | `string` | `'#CC0033'` | Color for highest value |
-| `colorMin` | `string` | `'#FFE5D9'` | Color for lowest value |
-| `colorNoData` | `string` | `'#E2E2E2'` | Color when there is no data |
-| `flagType` | `'image'`, `'emoji'` | `'image'` | The type of the flag in the tooltip |
-| `flagURL` | `string` | | The URL to the flags when using flag type `'image'`. The placeholder `{0}` will get replaced with the lowercase [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code. Default: `'https://cdn.jsdelivr.net/gh/hjnilsson/country-flags@latest/svg/{0}.svg'` |
-| `hideFlag` | `boolean` | `false` | Hide the flag in tooltips |
-| `noDataText` | `string` | `'No data available'` | The text to be shown when no data is present |
-| `touchLink` | `boolean` | `false` | Set to `true` to open the link (see `data.values.link`) on mobile devices, by default the tooltip will be shown |
-| `onGetTooltip` | `function` | | Called when a tooltip is created to custimize the tooltip content (`function (tooltipDiv, countryID, countryValues) { return 'Custom HTML'; }`) |
-| `countries` | `object` | | Additional options specific to countries: |
-| &nbsp;&nbsp;&nbsp;`↳ EH` | `boolean` | `true` | When set to `false`, Western Sahara (EH) will be combined with Morocco (MA) |
-| `data` | `object` | | The chart data to use for coloring and to show in the tooltip. Use a unique data-id as key and provide following options as value: |
-| &nbsp;&nbsp;&nbsp;`↳ name` | `string` | | The name of the data, it will be shown in the tooltip |
-| &nbsp;&nbsp;&nbsp;`↳ format` | `string` | | The format for the data value, `{0}` will be replaced with the actual value |
-| &nbsp;&nbsp;&nbsp;`↳ thousandSeparator` | `string` | `','` | The character to use as thousand separator |
-| &nbsp;&nbsp;&nbsp;`↳ thresholdMax` | `number` | `null` | Maximal value to use for coloring calculations |
-| &nbsp;&nbsp;&nbsp;`↳ thresholdMin` | `number` | `0` | Minimum value to use for coloring calculations |
-| &nbsp;&nbsp;&nbsp;`↳ applyData` | `string` | | The ID (key) of the data that will be used for coloring |
-| &nbsp;&nbsp;&nbsp;`↳ values` | `object` | | An object with the [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code as key and the chart data for each country as value |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`↳ color` | `string` | | Forces a color for this country |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`↳ link` | `string` | | An URL to redirect to when clicking the country |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`↳ linkTarget` | `string` | | The target of the link. By default the link will be opened in the same tab. Use `'_blank'` to open the link in a new tab |
-| `countryNames` | `object` | | An object with the [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code as key and the country name as value |
-
+| Option                                                         | Type                 | Default                           |                                                                                                                                                                                                                                                                                          |
+|----------------------------------------------------------------|----------------------|-----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `targetElementID`                                              | `string`             |                                   | The ID of the element where the world map will render (Required)                                                                                                                                                                                                                         |
+| `minZoom`                                                      | `float`              | `1`                               | Minimal zoom level                                                                                                                                                                                                                                                                       |
+| `maxZoom`                                                      | `float`              | `25`                              | Maximal zoom level                                                                                                                                                                                                                                                                       |
+| `initialZoom`                                                  | `float`              | `1.06`                            | Initial zoom level                                                                                                                                                                                                                                                                       |
+| `initialPan`                                                   | `object`             |                                   | Initial pan on x and y axis (e.g. `{ x: 30, y: 60 }`)                                                                                                                                                                                                                                    |
+| `showContinentSelector`                                        | `boolean`            | `false`                           | Show continent selector                                                                                                                                                                                                                                                                  |
+| `zoomScaleSensitivity`                                         | `float`              | `0.2`                             | Sensitivity when zooming                                                                                                                                                                                                                                                                 |
+| `showZoomReset`                                                | `boolean`            | `false`                           | Show zoom reset button                                                                                                                                                                                                                                                                   |
+| `mouseWheelZoomEnabled`                                        | `boolean`            | `true`                            | Enables or disables zooming with the scroll wheel                                                                                                                                                                                                                                        |
+| `mouseWheelZoomWithKey`                                        | `boolean`            | `false`                           | Allow zooming only when one of the following keys is pressed: SHIFT, CONTROL, ALT, COMMAND, OPTION                                                                                                                                                                                       |
+| `mouseWheelKeyMessage`                                         | `string`             | `'Press the [ALT] key to zoom'`   | The message when trying to scroll without a key                                                                                                                                                                                                                                          |
+| `mouseWheelKeyMessageMac`                                      | `string `            | `Press the [COMMAND] key to zoom` | The message when trying to scroll without a key on MacOS                                                                                                                                                                                                                                 |
+| `colorMax`                                                     | `string`             | `'#CC0033'`                       | Color for highest value                                                                                                                                                                                                                                                                  |
+| `colorMin`                                                     | `string`             | `'#FFE5D9'`                       | Color for lowest value                                                                                                                                                                                                                                                                   |
+| `colorNoData`                                                  | `string`             | `'#E2E2E2'`                       | Color when there is no data                                                                                                                                                                                                                                                              |
+| `flagType`                                                     | `'image'`, `'emoji'` | `'image'`                         | The type of the flag in the tooltip                                                                                                                                                                                                                                                      |
+| `flagURL`                                                      | `string`             |                                   | The URL to the flags when using flag type `'image'`. The placeholder `{0}` will get replaced with the lowercase [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code. Default: `'https://cdn.jsdelivr.net/gh/hjnilsson/country-flags@latest/svg/{0}.svg'` |
+| `hideFlag`                                                     | `boolean`            | `false`                           | Hide the flag in tooltips                                                                                                                                                                                                                                                                |
+| `noDataText`                                                   | `string`             | `'No data available'`             | The text to be shown when no data is present                                                                                                                                                                                                                                             |
+| `touchLink`                                                    | `boolean`            | `false`                           | Set to `true` to open the link (see `data.values.link`) on mobile devices, by default the tooltip will be shown                                                                                                                                                                          |
+| `onGetTooltip`                                                 | `function`           |                                   | Called when a tooltip is created to custimize the tooltip content (`function (tooltipDiv, countryID, countryValues) { return 'Custom HTML'; }`)                                                                                                                                          |
+| `countries`                                                    | `object`             |                                   | Additional options specific to countries:                                                                                                                                                                                                                                                |
+| &nbsp;&nbsp;&nbsp;`↳ EH`                                       | `boolean`            | `true`                            | When set to `false`, Western Sahara (EH) will be combined with Morocco (MA)                                                                                                                                                                                                              |
+| `data`                                                         | `object`             |                                   | The chart data to use for coloring and to show in the tooltip. Use a unique data-id as key and provide following options as value:                                                                                                                                                       |
+| &nbsp;&nbsp;&nbsp;`↳ name`                                     | `string`             |                                   | The name of the data, it will be shown in the tooltip                                                                                                                                                                                                                                    |
+| &nbsp;&nbsp;&nbsp;`↳ format`                                   | `string`             |                                   | The format for the data value, `{0}` will be replaced with the actual value                                                                                                                                                                                                              |
+| &nbsp;&nbsp;&nbsp;`↳ thousandSeparator`                        | `string`             | `','`                             | The character to use as thousand separator                                                                                                                                                                                                                                               |
+| &nbsp;&nbsp;&nbsp;`↳ thresholdMax`                             | `number`             | `null`                            | Maximal value to use for coloring calculations                                                                                                                                                                                                                                           |
+| &nbsp;&nbsp;&nbsp;`↳ thresholdMin`                             | `number`             | `0`                               | Minimum value to use for coloring calculations                                                                                                                                                                                                                                           |
+| &nbsp;&nbsp;&nbsp;`↳ applyData`                                | `string`             |                                   | The ID (key) of the data that will be used for coloring                                                                                                                                                                                                                                  |
+| &nbsp;&nbsp;&nbsp;`↳ values`                                   | `object`             |                                   | An object with the [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code as key and the chart data for each country as value                                                                                                                               |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`↳ color`      | `string`             |                                   | Forces a color for this country                                                                                                                                                                                                                                                          |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`↳ link`       | `string`             |                                   | An URL to redirect to when clicking the country                                                                                                                                                                                                                                          |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`↳ linkTarget` | `string`             |                                   | The target of the link. By default the link will be opened in the same tab. Use `'_blank'` to open the link in a new tab                                                                                                                                                                 |
+| `countryNames`                                                 | `object`             |                                   | An object with the [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code as key and the country name as value                                                                                                                                              |
 ---
+
+## Styling
+You can overwrite the following scss variables to customize the style of the map:
+
+| Variable                        | Default                      |
+|---------------------------------|------------------------------|
+| $textColor                      | #111                         |
+| $textColorLight                 | #777                         |
+| $oceanColor                     | #d9ecff                      |
+| $mapActiveStrokeColor           | #333                         |
+| $mapActiveStrokeWidth           | 1.5                          |
+| $blockZoomNoticeColor           | #fff                         |
+| $blockZoomNoticeBackgroundColor | rgba(0, 0, 0, 0.8)           |
+| $mapControlsColor               | #fff                         |
+| $mapControlsBackgroundColor     | #111                         |
+| $mapControlsDisabledColor       | #ccc                         |
+| $mapControlsBoxShadow           | 0 0 0 2px rgba(0, 0, 0, 0.1) |
+| $mapTooltipColor                | #111                         |
+| $mapTooltipBackgroundColor      | #fff                         |
+| $mapTooltipFlagBackgroundColor  | rgba(0, 0, 0, 0.15)          |
+| $mapTooltipBoxShadowColor       | rgba(0, 0, 0, 0.2)           |
+| $continentControlsBoxShadow     | 0 0 0 2px rgba(0, 0, 0, 0.1) |
+| $countryStrokeColor             | #fff                         |
+---
+
 
 ## Localize
 

--- a/src/scss/map.scss
+++ b/src/scss/map.scss
@@ -74,7 +74,7 @@
     display: flex;
     overflow: hidden;
     border-radius: 2px;
-    box-shadow: 0 0 0 2px $mapControlsBoxShadowColor;
+    box-shadow:  $mapControlsBoxShadow;
   }
 
   .svgMap-map-controls-zoom,
@@ -183,7 +183,7 @@
     z-index: 1;
     display: flex;
     border-radius: 2px;
-    box-shadow: 0 0 0 2px $continentControlsBoxShadowColor;
+    box-shadow: $continentControlsBoxShadow;
   }
 
   // Countries

--- a/src/scss/map.scss
+++ b/src/scss/map.scss
@@ -10,10 +10,10 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.8);
+  background: $blockZoomNoticeBackgroundColor;
   pointer-events: none;
   opacity: 0;
-  color: #fff;
+  color: $blockZoomNoticeColor;
   transition: opacity 250ms;
 
   .svgMap-block-zoom-notice-active & {
@@ -74,7 +74,7 @@
     display: flex;
     overflow: hidden;
     border-radius: 2px;
-    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 0 0 2px $mapControlsBoxShadowColor;
   }
 
   .svgMap-map-controls-zoom,
@@ -82,7 +82,7 @@
     display: flex;
     margin-right: 5px;
     overflow: hidden;
-    background: #fff;
+    background: $mapControlsBackgroundColor;
 
     &:last-child {
       margin-right: 0;
@@ -90,10 +90,10 @@
   }
 
   .svgMap-control-button {
-    background-color: transparent;
+    background-color: $mapControlsBackgroundColor;;
     border: none;
     border-radius: 0;
-    color: inherit;
+    color: $mapControlsColor;
     font: inherit;
     line-height: inherit;
     margin: 0;
@@ -116,7 +116,7 @@
         top: 50%;
         left: 50%;
         transform: translate(-50%, -50%);
-        background: #666;
+        background: $mapControlsBackgroundColor;
         transition: background-color 250ms;
       }
 
@@ -128,14 +128,14 @@
         width: 11px;
         height: 11px;
         background: none;
-        border: 2px solid #666;
+        border: 2px solid $mapControlsBackgroundColor;
       }
 
       @media (hover: hover) {
         &:hover {
           &:before,
           &:after {
-            background: $textColor;
+            background: $mapControlsBackgroundColor;
           }
         }
       }
@@ -143,19 +143,19 @@
       &:active {
         &:before,
         &:after {
-          background: $textColor;
+          background: $mapControlsBackgroundColor;
         }
       }
 
       &.svgMap-disabled {
         &:before,
         &:after {
-          background: #ccc;
+          background: $mapControlsDisabledColor;
         }
       }
       &.svgMap-zoom-reset-button {
         &.svgMap-disabled:before {
-          border: 2px solid #ccc;
+          border: 2px solid $mapControlsDisabledColor;
           background: none;
         }
       }
@@ -183,13 +183,13 @@
     z-index: 1;
     display: flex;
     border-radius: 2px;
-    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 0 0 2px $continentControlsBoxShadowColor;
   }
 
   // Countries
 
   .svgMap-country {
-    stroke: #fff;
+    stroke: $countryStrokeColor;
     stroke-width: 1;
     stroke-linejoin: round;
     vector-effect: non-scaling-stroke;

--- a/src/scss/tooltip.scss
+++ b/src/scss/tooltip.scss
@@ -1,11 +1,11 @@
 .svgMap-tooltip {
-  box-shadow: 0 0 3px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 3px $mapTooltipBoxShadowColor;
   position: absolute;
   z-index: 2;
   border-radius: 2px;
-  background: #fff;
+  background: $mapTooltipBackgroundColor;
   transform: translate(-50%, -100%);
-  border-bottom: 1px solid #000;
+  border-bottom: 1px solid $mapTooltipColor;
   display: none;
   pointer-events: none;
   min-width: 60px;
@@ -13,7 +13,7 @@
   &.svgMap-tooltip-flipped {
     transform: translate(-50%, 0);
     border-bottom: 0;
-    border-top: 1px solid #000;
+    border-top: 1px solid $mapTooltipColor;
   }
 
   &.svgMap-active {
@@ -40,7 +40,7 @@
         width: auto;
         height: 32px;
         padding: 2px;
-        background: rgba(0, 0, 0, 0.15);
+        background: $mapTooltipFlagBackgroundColor;
         border-radius: 2px;
       }
     }
@@ -107,8 +107,8 @@
       content: '';
       width: 20px;
       height: 20px;
-      background: #fff;
-      border: 1px solid #000;
+      background: $mapTooltipBackgroundColor;
+      border: 1px solid $mapTooltipColor;
       position: absolute;
       bottom: 6px;
       left: 50%;

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -1,28 +1,28 @@
 // General
-$textColor: #111;
-$textColorLight: #777;
+$textColor: #111 !default;
+$textColorLight: #777 !default;
 
 // Map
-$oceanColor: #d9ecff;
-$mapActiveStrokeColor: #333;
-$mapActiveStrokeWidth: 1.5;
-$blockZoomNoticeColor: #fff;
-$blockZoomNoticeBackgroundColor: rgba(0, 0, 0, 0.8);
+$oceanColor: #d9ecff !default;
+$mapActiveStrokeColor: #333 !default;
+$mapActiveStrokeWidth: 1.5 !default;
+$blockZoomNoticeColor: #fff !default;
+$blockZoomNoticeBackgroundColor: rgba(0, 0, 0, 0.8) !default;
 
 // Map Controls
 $mapControlsColor: #fff;
-$mapControlsBackgroundColor: #111;
-$mapControlsDisabledColor: #ccc;
-$mapControlsBoxShadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
+$mapControlsBackgroundColor: #111 !default;
+$mapControlsDisabledColor: #ccc !default;
+$mapControlsBoxShadow: 0 0 0 2px rgba(0, 0, 0, 0.1) !default;
 
 // Map Tooltip
-$mapTooltipColor: #111;
-$mapTooltipBackgroundColor: #fff;
-$mapTooltipFlagBackgroundColor: rgba(0, 0, 0, 0.15);
-$mapTooltipBoxShadowColor: rgba(0, 0, 0, 0.2);
+$mapTooltipColor: #111 !default;
+$mapTooltipBackgroundColor: #fff !default;
+$mapTooltipFlagBackgroundColor: rgba(0, 0, 0, 0.15) !default;
+$mapTooltipBoxShadowColor: rgba(0, 0, 0, 0.2) !default;
 
 // Continent Controls
-$continentControlsBoxShadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
+$continentControlsBoxShadow: 0 0 0 2px rgba(0, 0, 0, 0.1) !default;
 
 // Country
-$countryStrokeColor: #fff;
+$countryStrokeColor: #fff !default;

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -13,7 +13,7 @@ $blockZoomNoticeBackgroundColor: rgba(0, 0, 0, 0.8);
 $mapControlsColor: #fff;
 $mapControlsBackgroundColor: #111;
 $mapControlsDisabledColor: #ccc;
-$mapControlsBoxShadowColor: rgba(0, 0, 0, 0.1);
+$mapControlsBoxShadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
 
 // Map Tooltip
 $mapTooltipColor: #111;
@@ -22,7 +22,7 @@ $mapTooltipFlagBackgroundColor: rgba(0, 0, 0, 0.15);
 $mapTooltipBoxShadowColor: rgba(0, 0, 0, 0.2);
 
 // Continent Controls
-$continentControlsBoxShadowColor: rgba(0, 0, 0, 0.1);
+$continentControlsBoxShadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
 
 // Country
 $countryStrokeColor: #fff;

--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -6,3 +6,23 @@ $textColorLight: #777;
 $oceanColor: #d9ecff;
 $mapActiveStrokeColor: #333;
 $mapActiveStrokeWidth: 1.5;
+$blockZoomNoticeColor: #fff;
+$blockZoomNoticeBackgroundColor: rgba(0, 0, 0, 0.8);
+
+// Map Controls
+$mapControlsColor: #fff;
+$mapControlsBackgroundColor: #111;
+$mapControlsDisabledColor: #ccc;
+$mapControlsBoxShadowColor: rgba(0, 0, 0, 0.1);
+
+// Map Tooltip
+$mapTooltipColor: #111;
+$mapTooltipBackgroundColor: #fff;
+$mapTooltipFlagBackgroundColor: rgba(0, 0, 0, 0.15);
+$mapTooltipBoxShadowColor: rgba(0, 0, 0, 0.2);
+
+// Continent Controls
+$continentControlsBoxShadowColor: rgba(0, 0, 0, 0.1);
+
+// Country
+$countryStrokeColor: #fff;


### PR DESCRIPTION
This pull request adds the use of scss variables to control mostly the coloring of map elements. It also utilises the [!default](https://sass-lang.com/documentation/variables/#configuring-modules) configuration to allow overriding the variables when initializing a map.