### PR TITLE
Allow overriding mapControlsColor

### DIFF
--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -10,7 +10,7 @@ $blockZoomNoticeColor: #fff !default;
 $blockZoomNoticeBackgroundColor: rgba(0, 0, 0, 0.8) !default;
 
 // Map Controls
-$mapControlsColor: #fff;
+$mapControlsColor: #fff !default;
 $mapControlsBackgroundColor: #fff !default;
 $mapControlsIconColor: #ccc !default;
 $mapControlsIconColorActive: #000 !default;


### PR DESCRIPTION
Overriding the controls color is useful for e.g. implementing dark mode.