### PR TITLE
Consider a switch from linear to logarithmic color ratios

### DIFF
--- a/src/js/svgMap.js
+++ b/src/js/svgMap.js
@@ -423,7 +423,12 @@ function svgMapWrapper(svgPanZoom) {
           min,
           parseInt(data.values[countryID][data.applyData], 10)
         );
-        var ratio = Math.max(0, Math.min(1, (value - min) / (max - min)));
+
+        var logValue = Math.log(value + 1);
+        var logMin = Math.log(min + 1);
+        var logMax = Math.log(max + 1);
+        var ratio = Math.max(0, Math.min(1, (logValue - logMin) / (logMax - logMin)));
+
         var color = this.getColor(
           this.toHex(this.options.colorMax),
           this.toHex(this.options.colorMin),

--- a/src/js/svgMap.js
+++ b/src/js/svgMap.js
@@ -432,12 +432,28 @@ function svgMapWrapper(svgPanZoom) {
         var color = this.getColor(
           this.toHex(this.options.colorMax),
           this.toHex(this.options.colorMin),
-          ratio || ratio === 0 ? ratio : 1
+          this.calculateColorRatio(value, min, max)
         );
         element.setAttribute('fill', color);
       }.bind(this)
     );
   };
+
+  svgMap.prototype.calculateColorRatio = function (value, min, max)  {
+    var range = max - min;
+    var positionInRange = value - min;
+
+    if(range === 0 || positionInRange === 0) {
+      return 0;
+    }
+
+    var logValue = Math.log(positionInRange + 1);
+    var logMin = Math.log(1);
+    var logMax = Math.log(range + 1);
+    var ratio = Math.max(0, Math.min(1, (logValue - logMin) / (logMax - logMin)));
+
+    return ratio || ratio === 0 ? ratio : 1;
+  }
 
   // Emoji flags
 

--- a/src/js/svgMap.js
+++ b/src/js/svgMap.js
@@ -424,11 +424,6 @@ function svgMapWrapper(svgPanZoom) {
           parseInt(data.values[countryID][data.applyData], 10)
         );
 
-        var logValue = Math.log(value + 1);
-        var logMin = Math.log(min + 1);
-        var logMax = Math.log(max + 1);
-        var ratio = Math.max(0, Math.min(1, (logValue - logMin) / (logMax - logMin)));
-
         var color = this.getColor(
           this.toHex(this.options.colorMax),
           this.toHex(this.options.colorMin),


### PR DESCRIPTION
Thanks for merging my pull request that introduced `allowInteraction`. We're now using svgMap in production!

Our maps have a wide range of data. Imagine a map showing the number of visitors from various countries. The United States with 10,000, Canada with 1,500 and dozens of countries with less than 50 visitors.

With this dataset and the [current linear ratio calculation](https://github.com/StephanWagner/svgMap/blob/master/src/js/svgMap.js#L433), it becomes impossible to see the color differences between many of the countries since the outliers are so large. A majority of the countries get muddied together at the low end.

**This pull request switches the color ratio calculation from a linear one over to a logarithmic one. This gives countries with different values visually distinct colors even when there are large outliers in the data.**

The labeled gif below shows the differences.

For the linear map, it's not possible to tell the difference between India, Pakistan, and Afghanistan, even though India has 3x as many visitors as Afghanistan. In the logarithmic map, more of the color spectrum between `colorMin` and `colorMax` is used to make this more obvious.

Let me know what you think! Thanks.

![map](https://github.com/user-attachments/assets/1d940e9b-d0e3-463b-806f-7fdf1c646073)