### PR TITLE
Add 'src' and 'assets' to package.json files list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svgmap",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "svgmap",
-      "version": "2.18.1",
+      "version": "2.18.2",
       "license": "MIT",
       "dependencies": {
         "svg-pan-zoom": "^3.6.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svgmap",
   "description": "svgMap is a JavaScript library that lets you easily create an interactable world map comparing customizable data for each country.",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "type": "module",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "*.css"
   ],
   "files": [
-    "dist"
+    "dist",
+    "src",
+    "assets"
   ],
   "dependencies": {
     "svg-pan-zoom": "^3.6.2"


### PR DESCRIPTION
This MR fixes missing files in npm release, that cause map to break if code relies on them for example regarding the [styling](https://github.com/stephanwagner/svgMap?tab=readme-ov-file#styling)

release: 2.18.2