### PR TITLE
fix: require svg-pan-zoom because it is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svgmap",
   "description": "svgMap is a JavaScript library that lets you easily create an interactable world map comparing customizable data for each country.",
-  "version": "2.18.2",
+  "version": "2.18.3",
   "type": "module",
   "license": "MIT",
   "keywords": [

--- a/src/js/core/svg-map.js
+++ b/src/js/core/svg-map.js
@@ -1,3 +1,5 @@
+const svgPanZoom = require('svg-pan-zoom');
+
 export default class svgMap {
   constructor(options = {}) {
     const defaultOptions = {
@@ -1152,7 +1154,7 @@ export default class svgMap {
     var me = this;
 
     // Init pan zoom
-    this.mapPanZoom = svgPanZoom(this.mapImage, {
+    this.mapPanZoom = svgPanZoom.svgPanZoom(this.mapImage, {
       zoomEnabled: this.options.allowInteraction,
       panEnabled: this.options.allowInteraction,
       fit: true,


### PR DESCRIPTION
When using svgMap, we had to require svg-pan-zoom because we needed to set it for our build tool. In svg-map.js, "svgPanZoom" is used, but without import/require.

This MR requires svgPanZoom in svg-map.js so that users of svgMap do not need to require svg-pan-zoom and set it.

Release: 2.18.3