### PR TITLE
fix: call svgPanZoom constructor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svgmap",
-  "version": "2.18.2",
+  "version": "2.18.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "svgmap",
-      "version": "2.18.2",
+      "version": "2.18.4",
       "license": "MIT",
       "dependencies": {
         "svg-pan-zoom": "^3.6.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svgmap",
   "description": "svgMap is a JavaScript library that lets you easily create an interactable world map comparing customizable data for each country.",
-  "version": "2.18.3",
+  "version": "2.18.4",
   "type": "module",
   "license": "MIT",
   "keywords": [

--- a/src/js/core/svg-map.js
+++ b/src/js/core/svg-map.js
@@ -1154,7 +1154,7 @@ export default class svgMap {
     var me = this;
 
     // Init pan zoom
-    this.mapPanZoom = svgPanZoom.svgPanZoom(this.mapImage, {
+    this.mapPanZoom = svgPanZoom(this.mapImage, {
       zoomEnabled: this.options.allowInteraction,
       panEnabled: this.options.allowInteraction,
       fit: true,


### PR DESCRIPTION
Hi :smile: 

After recently updating to version `2.18.3` I always encounter the following error when loading the map: 

<img width="429" height="109" alt="image" src="https://github.com/user-attachments/assets/3273a87c-67b6-4a42-9d25-fbcecade2b80" />

This error seems to happen due to `svgPanZoom.svgPanZoom` being undefined.

<img width="408" height="58" alt="image" src="https://github.com/user-attachments/assets/5ae31d71-932c-47a9-b910-2d7ef431b538" />

When looking at it with the debugger it seems like we should be calling `svgPanZoom()` instead of `svgPanZoom.svgPanZoom()` for the initialization.

<img width="557" height="281" alt="image" src="https://github.com/user-attachments/assets/95e57ccf-c61c-4624-ac2a-a5cdbd84b85f" />

After testing it with the proposed change everything seems to work as expected again. 
Is this a general issue or might this be something that only affects my specific setup?

@m1rm Is there a specific reason you changed it in [this commit](https://github.com/stephanwagner/svgMap/commit/07eb13ab6d3e58eef5ebd78446dde01971b73ae5)?