### PR TITLE
Fix initial color flash on map load

### DIFF
--- a/src/js/core/svg-map.js
+++ b/src/js/core/svg-map.js
@@ -816,6 +816,10 @@ export default class svgMap {
       'svgMap-map-wrapper',
       this.mapContainer
     );
+    this.mapWrapper.style.setProperty(
+      '--svg-map-country-fill',
+      this.toHex(this.options.colorNoData)
+    );
     this.mapImage = document.createElementNS(
       'http://www.w3.org/2000/svg',
       'svg'


### PR DESCRIPTION
## Summary

On load, country paths briefly render with the hardcoded CSS fallback color (`#E2E2E2`) before `applyData()` sets the final colors. Combined with the `fill 250ms` CSS transition, this causes a noticeable flash — especially when `colorNoData` differs significantly from the default (e.g. dark themes).

## Solution

Set `--svg-map-country-fill` CSS variable on the map wrapper to `colorNoData` before SVG paths render. Since the variable cascades to all `.svgMap-country` elements, they start with the correct color. Only countries with data smoothly transition to their data color.