### PR TITLE
feat(#181): add onCountryClick callback including demo examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ You can pass the following options into svgMap:
 | `noDataText` | `string` | `'No data available'` | The text to be shown when no data is present |
 | `touchLink` | `boolean` | `false` | Set to `true` to open the link (see `data.values.link`) on mobile devices, by default the tooltip will be shown |
 | `onGetTooltip` | `function` | | Called when a tooltip is created to custimize the tooltip content (`function (tooltipDiv, countryID, countryValues) { return 'Custom HTML'; }`) |
+| `onCountryClick` | `function` | | Called when the user clicks a country (primary button, pointer released without dragging). Signature: `function (countryID, event) { … }`. Use this for custom actions instead of or in addition to `data.values.link`. Return `false` to skip opening the URL when the country has a `link`. On touch devices with a link, the callback runs when the tap would navigate (not on the first tap that only shows the tooltip). Countries show a pointer cursor while this option is set. |
 | `countries` | `object` | | Additional options specific to countries: |
 | &nbsp;&nbsp;&nbsp;`↳ EH` | `boolean` | `true` | When set to `false`, Western Sahara (EH) will be combined with Morocco (MA) |
 | `data` | `object` | | The chart data to use for coloring and to show in the tooltip. Use a unique data-id as key and provide following options as value: |

--- a/demo/html/demo.css
+++ b/demo/html/demo.css
@@ -21,6 +21,18 @@ body {
   padding: 0 0 80px;
 }
 
+.demo-click-result {
+  box-sizing: border-box;
+  margin-top: 16px;
+  padding: 16px 20px;
+  border: 2px solid #111;
+  border-radius: 4px;
+  background: #f8f8f8;
+  font-size: 18px;
+  line-height: 1.4;
+  min-height: 1.4em;
+}
+
 h2 {
   text-align: center;
   font-size: 32px;

--- a/demo/html/index.html
+++ b/demo/html/index.html
@@ -31,6 +31,35 @@
         </script>
       </div>
 
+      <!-- Demo country click callback -->
+
+      <div class="demo-container">
+        <h2>Country click callback</h2>
+
+        <div id="svgMapClickCallback"></div>
+        <div
+          id="svgMapClickCallbackResult"
+          class="demo-click-result"
+        >
+          Click a country on the map.
+        </div>
+        <script>
+          var svgMapClickCallbackDemo = new svgMap({
+            targetElementID: 'svgMapClickCallback',
+            data: svgMapDataGPD,
+            mouseWheelZoomEnabled: true,
+            mouseWheelZoomWithKey: true,
+            onCountryClick: function (countryID) {
+              var label =
+                svgMapClickCallbackDemo.countries[countryID] || countryID;
+              document.getElementById('svgMapClickCallbackResult').textContent =
+                'Selected: ' + label + ' (' + countryID + ')';
+              return false;
+            }
+          });
+        </script>
+      </div>
+
       <!-- Demo population -->
 
       <div class="demo-container">

--- a/demo/react/src/App.css
+++ b/demo/react/src/App.css
@@ -1,4 +1,30 @@
 .app {
   text-align: center;
   font-family: sans-serif;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 24px 16px 80px;
+}
+
+.demo-section {
+  padding-bottom: 48px;
+}
+
+.demo-section h2 {
+  font-size: 28px;
+  font-weight: normal;
+  margin: 0 0 24px;
+}
+
+.demo-click-result {
+  box-sizing: border-box;
+  margin-top: 16px;
+  padding: 16px 20px;
+  border: 2px solid #111;
+  border-radius: 4px;
+  background: #f8f8f8;
+  font-size: 18px;
+  line-height: 1.4;
+  min-height: 1.4em;
+  text-align: left;
 }

--- a/demo/react/src/App.js
+++ b/demo/react/src/App.js
@@ -6,38 +6,58 @@ import './App.css';
 import svgMap from 'svgmap';
 import 'svgmap/style';
 
+const sampleGdpData = {
+  data: {
+    gdp: {
+      name: 'GDP per capita',
+      format: '{0} USD',
+      thousandSeparator: ',',
+      thresholdMax: 50000,
+      thresholdMin: 1000
+    },
+    change: {
+      name: 'Change to year before',
+      format: '{0} %'
+    }
+  },
+  applyData: 'gdp',
+  values: {
+    AF: { gdp: 587, change: 4.73 },
+    AL: { gdp: 4583, change: 11.09 },
+    DZ: { gdp: 4293, change: 10.01 }
+    // ...
+  }
+};
+
 class App extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      clickDemoSelection: 'Click a country on the map.'
+    };
+  }
 
   componentDidMount() {
     if (!this.svgMap) {
-
-      var mySvgMap = new svgMap({
+      this.svgMap = new svgMap({
         targetElementID: 'svgMap',
-        data: {
-          data: {
-            gdp: {
-              name: 'GDP per capita',
-              format: '{0} USD',
-              thousandSeparator: ',',
-              thresholdMax: 50000,
-              thresholdMin: 1000
-            },
-            change: {
-              name: 'Change to year before',
-              format: '{0} %'
-            }
-          },
-          applyData: 'gdp',
-          values: {
-            AF: { gdp: 587, change: 4.73 },
-            AL: { gdp: 4583, change: 11.09 },
-            DZ: { gdp: 4293, change: 10.01 }
-            // ...
-          }
+        data: sampleGdpData
+      });
+    }
+
+    if (!this.clickDemoMap) {
+      const clickDemoMap = new svgMap({
+        targetElementID: 'svgMapClickCallback',
+        data: sampleGdpData,
+        onCountryClick: (countryID) => {
+          const label = clickDemoMap.countries[countryID] || countryID;
+          this.setState({
+            clickDemoSelection: `Selected: ${label} (${countryID})`
+          });
+          return false;
         }
       });
-
-      this.svgMap = mySvgMap;
+      this.clickDemoMap = clickDemoMap;
     }
   }
 
@@ -45,7 +65,17 @@ class App extends Component {
     return (
       <div className='app'>
         <h1>svgMap React demo</h1>
-        <div id='svgMap'></div>
+
+        <section className='demo-section'>
+          <h2>GDP per capita (sample)</h2>
+          <div id='svgMap'></div>
+        </section>
+
+        <section className='demo-section'>
+          <h2>Country click callback</h2>
+          <div id='svgMapClickCallback'></div>
+          <div className='demo-click-result'>{this.state.clickDemoSelection}</div>
+        </section>
       </div>
     );
   }

--- a/src/js/core/svg-map.js
+++ b/src/js/core/svg-map.js
@@ -78,6 +78,10 @@ export default class svgMap {
         return null;
       },
 
+      // Called on country click (pointer released without dragging). Receives
+      // (countryID, event). Return false to skip opening data.values[*].link.
+      onCountryClick: null,
+
       // Country specific options
       countries: {
         // Western Sahara: Set to false to combine Morocco (MA) and Western Sahara (EH)
@@ -117,6 +121,9 @@ export default class svgMap {
     // Wrapper element
     this.wrapper = document.getElementById(this.options.targetElementID);
     this.wrapper.classList.add('svgMap-wrapper');
+    if (typeof this.options.onCountryClick === 'function') {
+      this.wrapper.classList.add('svgMap-country-click-callback');
+    }
 
     // Container element
     this.container = document.createElement('div');
@@ -1120,15 +1127,33 @@ export default class svgMap {
 
       const countryID = countryElement.getAttribute('data-id');
       const link = countryElement.getAttribute('data-link');
-      const target = countryElement.getAttribute('data-link-target');
-      if (!link) return;
-
+      const linkTarget = countryElement.getAttribute('data-link-target');
+      const hasCallback = typeof this.options.onCountryClick === 'function';
+      const hasLink = !!link;
       const isTouch = e.pointerType === 'touch' || e.pointerType === 'pen';
+
+      if (!hasLink && !hasCallback) return;
+
+      const willNavigate =
+        hasLink &&
+        (!isTouch || countryElement.classList.contains('svgMap-active'));
+
+      const shouldFireCallback =
+        hasCallback && (!hasLink || !isTouch || willNavigate);
+
+      var callbackResult;
+      if (shouldFireCallback) {
+        callbackResult = this.options.onCountryClick(countryID, e);
+      }
+
+      if (!hasLink) return;
+
+      if (callbackResult === false) return;
 
       if (isTouch) {
         // Touch: only open if already active
         if (countryElement.classList.contains('svgMap-active')) {
-          if (target) window.open(link, target);
+          if (linkTarget) window.open(link, linkTarget);
           else window.location.href = link;
         } else {
           // first tap shows tooltip
@@ -1140,7 +1165,7 @@ export default class svgMap {
         }
       } else {
         // Desktop: open immediately
-        if (target) window.open(link, target);
+        if (linkTarget) window.open(link, linkTarget);
         else window.location.href = link;
       }
     });

--- a/src/scss/map.scss
+++ b/src/scss/map.scss
@@ -255,3 +255,7 @@
     }
   }
 }
+
+.svgMap-wrapper.svgMap-country-click-callback .svgMap-map-wrapper .svgMap-country {
+  cursor: pointer;
+}


### PR DESCRIPTION
# PR Summary
This PR adds an optional **onCountryClick callback** so users of the library can run custom logic when a country is activated by click, without wiring DOM listeners to each country path. 

## Motivation
Previously, the supported way to react to a country interaction was data.values[code].link (navigation). Anything richer required workarounds (see https://github.com/stephanwagner/svgMap/issues/181). A first-class callback keeps behavior inside the library (drag vs. click, touch vs. mouse) and matches how onGetTooltip is used.


closes https://github.com/stephanwagner/svgMap/issues/181