### PR TITLE
Improve performance

### DIFF
--- a/src/js/core/svg-map.js
+++ b/src/js/core/svg-map.js
@@ -1202,14 +1202,6 @@ export default class svgMap {
     });
 
     this._clickTooltipOutsideHandler = function (ev) {
-      if (ev.pointerType !== 'mouse') return;
-      if (
-        !this.options.showTooltips ||
-        this.options.tooltipTrigger !== 'click' ||
-        !this.tooltip
-      ) {
-        return;
-      }
       if (!this.tooltip.classList.contains('svgMap-active')) return;
       var node = ev.target;
       if (
@@ -1228,11 +1220,6 @@ export default class svgMap {
           });
       }
     }.bind(this);
-    document.addEventListener(
-      'pointerdown',
-      this._clickTooltipOutsideHandler,
-      true
-    );
 
     // Expose instance
     var me = this;
@@ -2360,6 +2347,17 @@ export default class svgMap {
       return;
     }
     this.tooltip.classList.add('svgMap-active');
+
+    if (e.pointerType !== 'mouse' || (this.options.showTooltips && this.options.tooltipTrigger === 'click')) {
+      requestAnimationFrame(() => {
+        document.addEventListener(
+          'pointerdown',
+          this._clickTooltipOutsideHandler,
+          { once: true, passive: true },
+        );
+      });
+    }
+
     this.moveTooltip(e);
   }
 
@@ -2369,7 +2367,9 @@ export default class svgMap {
     if (!this.tooltip) {
       return;
     }
+
     this.tooltip.classList.remove('svgMap-active');
+    document.removeEventListener('pointerdown', this._clickTooltipOutsideHandler);
   }
 
   // Move the tooltip

--- a/src/js/core/svg-map.js
+++ b/src/js/core/svg-map.js
@@ -1014,7 +1014,7 @@ export default class svgMap {
       );
       countryElement.classList.add('svgMap-active');
 
-      const countryID = countryElement.getAttribute('data-id');
+      const countryID = countryElement.dataset.id;
       if (this.options.showTooltips) {
         this.setTooltipContent(this.getTooltipContent(countryID));
         this.showTooltip(e);
@@ -1043,7 +1043,7 @@ export default class svgMap {
           'id',
           this.id + '-map-country-' + countryID
         );
-        countryElement.setAttribute('data-id', countryID);
+        countryElement.dataset.id = countryID;
         countryElement.classList.add('svgMap-country');
 
         this.mapImage.appendChild(countryElement);
@@ -1054,15 +1054,9 @@ export default class svgMap {
           this.options.data.values[countryID] &&
           this.options.data.values[countryID]['link']
         ) {
-          countryElement.setAttribute(
-            'data-link',
-            this.options.data.values[countryID]['link']
-          );
+          countryElement.dataset.link = this.options.data.values[countryID]['link'];
           if (this.options.data.values[countryID]['linkTarget']) {
-            countryElement.setAttribute(
-              'data-link-target',
-              this.options.data.values[countryID]['linkTarget']
-            );
+            countryElement.dataset.linkTarget = this.options.data.values[countryID]['linkTarget'];
           }
         }
       }.bind(this)
@@ -1108,9 +1102,9 @@ export default class svgMap {
       const countryElement = e.target.closest('.svgMap-country');
       if (!countryElement) return;
 
-      const countryID = countryElement.getAttribute('data-id');
-      const link = countryElement.getAttribute('data-link');
-      const linkTarget = countryElement.getAttribute('data-link-target');
+      const countryID = countryElement.dataset.id;
+      const link = countryElement.dataset.link;
+      const linkTarget = countryElement.dataset.linkTarget;
       const hasCallback = typeof this.options.onCountryClick === 'function';
       const hasLink = !!link;
       const isTouch = e.pointerType === 'touch' || e.pointerType === 'pen';
@@ -1302,7 +1296,7 @@ export default class svgMap {
 
     countryElements.forEach(
       function (countryElement) {
-        var countryID = countryElement.getAttribute('data-id');
+        var countryID = countryElement.dataset.id;
         if (!this.shouldShowTooltipOnLoad(countryID)) {
           return;
         }
@@ -2349,6 +2343,8 @@ export default class svgMap {
     this.tooltip.classList.add('svgMap-active');
 
     if (e.pointerType !== 'mouse' || (this.options.showTooltips && this.options.tooltipTrigger === 'click')) {
+      // don't register event listener in the same frame
+      // to prevent it from being triggered immediately
       requestAnimationFrame(() => {
         document.addEventListener(
           'pointerdown',

--- a/src/js/core/svg-map.js
+++ b/src/js/core/svg-map.js
@@ -953,6 +953,26 @@ export default class svgMap {
 
     // Add map elements
     var countryElements = [];
+
+    this.mapImage.addEventListener('pointerleave', e => {
+      this.hideTooltip();
+    }, { passive: true });
+
+    this.mapImage.addEventListener('pointercancel', e => {
+      this.hideTooltip();
+    }, { passive: true });
+
+    // Handle touch move - update tooltip position while panning
+    this.mapImage.addEventListener('pointermove', e => {
+      const target = e.target;
+      if (target?.tagName !== 'path') {
+        this.hideTooltip();
+        return;
+      }
+
+      this.moveTooltip(e);
+    }, { passive: true });
+
     Object.keys(mapPaths).forEach(
       function (countryID) {
         var countryData = this.mapPaths[countryID];
@@ -976,26 +996,6 @@ export default class svgMap {
         this.mapImage.appendChild(countryElement);
         countryElements.push(countryElement);
 
-        // Add tooltip when touch is used
-        function handlePointerMove(e) {
-          if (e.pointerType === 'touch') return;
-
-          const target = document.elementFromPoint(e.clientX, e.clientY);
-
-          if (
-            !target ||
-            (!target.closest('.svgMap-country') &&
-              !target.closest('.svgMap-tooltip'))
-          ) {
-            this.hideTooltip();
-            document
-              .querySelectorAll('.svgMap-active')
-              .forEach((el) => el.classList.remove('svgMap-active'));
-          }
-        }
-
-        const handlePointerMoveBound = handlePointerMove.bind(this);
-
         countryElement.addEventListener(
           'pointerenter',
           function (e) {
@@ -1005,13 +1005,6 @@ export default class svgMap {
               this.options.tooltipTrigger === 'click'
             ) {
               return;
-            }
-
-            // Only add pointermove listener for non-touch pointers
-            if (e.pointerType !== 'touch') {
-              document.addEventListener('pointermove', handlePointerMoveBound, {
-                passive: true
-              });
             }
 
             document
@@ -1035,15 +1028,6 @@ export default class svgMap {
               }
             }
           }.bind(this)
-        );
-
-        // Handle touch move - update tooltip position while panning
-        countryElement.addEventListener(
-          'touchmove',
-          function (e) {
-            this.moveTooltip(e);
-          }.bind(this),
-          { passive: true }
         );
 
         // Handle touch end - remove active state and hide tooltip
@@ -1076,10 +1060,6 @@ export default class svgMap {
           'pointerleave',
           function (e) {
             if (e.pointerType !== 'touch') {
-              document.removeEventListener(
-                'pointermove',
-                handlePointerMoveBound
-              );
               if (
                 !(
                   e.pointerType === 'mouse' &&

--- a/src/js/core/svg-map.js
+++ b/src/js/core/svg-map.js
@@ -955,10 +955,32 @@ export default class svgMap {
     var countryElements = [];
 
     this.mapImage.addEventListener('pointerdown', e => {
+      if (!this.options.showTooltips) {
+        return;
+      }
+
+      this.mapImage.querySelectorAll('.svgMap-active')
+        .forEach((el) => el.classList.remove('svgMap-active'));
+
+      const countryElement = e.target;
+      if (countryElement?.tagName !== 'path') {
+        this.hideTooltip();
+        return;
+      }
+
+      countryElement.parentNode.insertBefore(
+        countryElement,
+        this.persistentTooltipGroup || null
+      );
+      countryElement.classList.add('svgMap-active');
+
+      const countryID = countryElement.dataset.id;
+      this.setTooltipContent(this.getTooltipContent(countryID));
+      this.showTooltip(e);
+
+      // For touch, move tooltip to the touch position and keep it there
       if (e.pointerType === 'touch') {
-        if (e.target?.tagName !== 'path') {
-          this.hideTooltip();
-        }
+        this.moveTooltip(e);
       }
     }, { passive: true });
 
@@ -1018,52 +1040,6 @@ export default class svgMap {
 
         this.mapImage.appendChild(countryElement);
         countryElements.push(countryElement);
-
-        // Handle touch end - remove active state and hide tooltip
-        countryElement.addEventListener(
-          'touchend',
-          function (e) {
-            const touch = e.changedTouches[0];
-            const elementAtEnd = document.elementFromPoint(
-              touch.clientX,
-              touch.clientY
-            );
-
-            // Only hide if touch ended outside the country or tooltip
-            if (
-              !elementAtEnd ||
-              (!elementAtEnd.closest('.svgMap-country') &&
-                !elementAtEnd.closest('.svgMap-tooltip'))
-            ) {
-              this.hideTooltip();
-              document
-                .querySelectorAll('.svgMap-active')
-                .forEach((el) => el.classList.remove('svgMap-active'));
-            }
-          }.bind(this),
-          { passive: true }
-        );
-
-        // Remove pointermove listener when leaving non-touch pointer
-        countryElement.addEventListener(
-          'pointerleave',
-          function (e) {
-            if (e.pointerType !== 'touch') {
-              if (
-                !(
-                  e.pointerType === 'mouse' &&
-                  this.options.showTooltips &&
-                  this.options.tooltipTrigger === 'click'
-                )
-              ) {
-                this.hideTooltip();
-                document
-                  .querySelectorAll('.svgMap-active')
-                  .forEach((el) => el.classList.remove('svgMap-active'));
-              }
-            }
-          }.bind(this)
-        );
 
         if (
           this.options.data.values &&

--- a/src/js/core/svg-map.js
+++ b/src/js/core/svg-map.js
@@ -968,13 +968,32 @@ export default class svgMap {
 
     // Handle touch move - update tooltip position while panning
     this.mapImage.addEventListener('pointermove', e => {
-      const target = e.target;
-      if (target?.tagName !== 'path') {
+      const countryElement = e.target;
+      if (countryElement?.tagName !== 'path') {
         this.hideTooltip();
         return;
       }
 
-      this.moveTooltip(e);
+      document
+        .querySelectorAll('.svgMap-active')
+        .forEach((el) => el.classList.remove('svgMap-active'));
+
+      countryElement.parentNode.insertBefore(
+        countryElement,
+        this.persistentTooltipGroup || null
+      );
+      countryElement.classList.add('svgMap-active');
+
+      const countryID = countryElement.getAttribute('data-id');
+      if (this.options.showTooltips) {
+        this.setTooltipContent(this.getTooltipContent(countryID));
+        this.showTooltip(e);
+
+        // For touch, move tooltip to the touch position and keep it there
+        if (e.pointerType === 'touch') {
+          this.moveTooltip(e);
+        }
+      }
     }, { passive: true });
 
     Object.keys(mapPaths).forEach(
@@ -999,40 +1018,6 @@ export default class svgMap {
 
         this.mapImage.appendChild(countryElement);
         countryElements.push(countryElement);
-
-        countryElement.addEventListener(
-          'pointerenter',
-          function (e) {
-            if (
-              e.pointerType === 'mouse' &&
-              this.options.showTooltips &&
-              this.options.tooltipTrigger === 'click'
-            ) {
-              return;
-            }
-
-            document
-              .querySelectorAll('.svgMap-active')
-              .forEach((el) => el.classList.remove('svgMap-active'));
-
-            countryElement.parentNode.insertBefore(
-              countryElement,
-              this.persistentTooltipGroup || null
-            );
-            countryElement.classList.add('svgMap-active');
-
-            const countryID = countryElement.getAttribute('data-id');
-            if (this.options.showTooltips) {
-              this.setTooltipContent(this.getTooltipContent(countryID));
-              this.showTooltip(e);
-
-              // For touch, move tooltip to the touch position and keep it there
-              if (e.pointerType === 'touch') {
-                this.moveTooltip(e);
-              }
-            }
-          }.bind(this)
-        );
 
         // Handle touch end - remove active state and hide tooltip
         countryElement.addEventListener(

--- a/src/js/core/svg-map.js
+++ b/src/js/core/svg-map.js
@@ -954,16 +954,21 @@ export default class svgMap {
     // Add map elements
     var countryElements = [];
 
+    const clearActive = function clearActive() {
+      this.mapImage.querySelectorAll('.svgMap-active')
+        .forEach((el) => el.classList.remove('svgMap-active'));
+    }.bind(this);
+
     this.mapImage.addEventListener('pointerdown', e => {
       if (!this.options.showTooltips) {
         return;
       }
 
-      this.mapImage.querySelectorAll('.svgMap-active')
-        .forEach((el) => el.classList.remove('svgMap-active'));
+      clearActive();
 
       const countryElement = e.target;
       if (countryElement?.tagName !== 'path') {
+        clearActive();
         this.hideTooltip();
         return;
       }
@@ -992,13 +997,12 @@ export default class svgMap {
     this.mapImage.addEventListener('pointermove', e => {
       const countryElement = e.target;
       if (countryElement?.tagName !== 'path') {
+        clearActive();
         this.hideTooltip();
         return;
       }
 
-      document
-        .querySelectorAll('.svgMap-active')
-        .forEach((el) => el.classList.remove('svgMap-active'));
+      clearActive();
 
       countryElement.parentNode.insertBefore(
         countryElement,
@@ -1130,9 +1134,7 @@ export default class svgMap {
             if (linkTarget) window.open(link, linkTarget);
             else window.location.href = link;
           } else {
-            this.mapImage
-              .querySelectorAll('.svgMap-country.svgMap-active')
-              .forEach((el) => el.classList.remove('svgMap-active'));
+            clearActive();
             countryElement.parentNode.insertBefore(
               countryElement,
               this.persistentTooltipGroup || null
@@ -1146,9 +1148,7 @@ export default class svgMap {
 
         if (callbackResultClick === false) return;
 
-        this.mapImage
-          .querySelectorAll('.svgMap-country.svgMap-active')
-          .forEach((el) => el.classList.remove('svgMap-active'));
+        clearActive();
         countryElement.parentNode.insertBefore(
           countryElement,
           this.persistentTooltipGroup || null

--- a/src/js/core/svg-map.js
+++ b/src/js/core/svg-map.js
@@ -954,8 +954,12 @@ export default class svgMap {
     // Add map elements
     var countryElements = [];
 
-    this.mapImage.addEventListener('pointerleave', e => {
-      this.hideTooltip();
+    this.mapImage.addEventListener('pointerdown', e => {
+      if (e.pointerType === 'touch') {
+        if (e.target?.tagName !== 'path') {
+          this.hideTooltip();
+        }
+      }
     }, { passive: true });
 
     this.mapImage.addEventListener('pointercancel', e => {
@@ -1074,26 +1078,6 @@ export default class svgMap {
               }
             }
           }.bind(this)
-        );
-
-        document.addEventListener(
-          'pointerover',
-          function (e) {
-            if (e.pointerType !== 'touch') return;
-
-            if (
-              e.target.closest('.svgMap-country') ||
-              e.target.closest('.svgMap-tooltip')
-            ) {
-              return;
-            }
-
-            this.hideTooltip();
-            document
-              .querySelectorAll('.svgMap-active')
-              .forEach((el) => el.classList.remove('svgMap-active'));
-          }.bind(this),
-          { passive: true }
         );
 
         if (

--- a/src/js/core/svg-map.js
+++ b/src/js/core/svg-map.js
@@ -959,6 +959,8 @@ export default class svgMap {
         .forEach((el) => el.classList.remove('svgMap-active'));
     }.bind(this);
 
+    const isClickTooltip = this.options.showTooltips && this.options.tooltipTrigger === 'click';
+
     this.mapImage.addEventListener('pointerdown', e => {
       if (!this.options.showTooltips) {
         return;
@@ -995,6 +997,8 @@ export default class svgMap {
 
     // Handle touch move - update tooltip position while panning
     this.mapImage.addEventListener('pointermove', e => {
+      if (e.pointerType === 'mouse' && isClickTooltip) return;
+
       const countryElement = e.target;
       if (countryElement?.tagName !== 'path') {
         clearActive();
@@ -1111,14 +1115,11 @@ export default class svgMap {
       const hasLink = !!link;
       const isTouch = e.pointerType === 'touch' || e.pointerType === 'pen';
 
-      const isClickTooltipMouse =
-        e.pointerType === 'mouse' &&
-        this.options.showTooltips &&
-        this.options.tooltipTrigger === 'click';
+      const isClickTooltipMouse = e.pointerType === 'mouse' && isClickTooltip;
 
       if (!hasLink && !hasCallback && !isClickTooltipMouse) return;
 
-      if (isClickTooltipMouse && this.options.showTooltips) {
+      if (isClickTooltipMouse) {
         const willNavigate =
           hasLink && countryElement.classList.contains('svgMap-active');
         const shouldFireCallback = hasCallback && (!hasLink || willNavigate);


### PR DESCRIPTION
This PR aims to fix 3 performance issues that I found in version 2.20.0:

- The script keeps adding and removing the `.svgMap-active` class on tooltip, even when the mouse is not moving, multiple times per second.
- `document`'s `pointerover` event gets called multiple times per second, even when you're not interacting with the map
- `_clickTooltipOutsideHandler()` get called even when the tooltip isn't shown

<img width="771" height="582" alt="svgmap-active" src="https://github.com/user-attachments/assets/b4e54951-d22d-4561-99b9-e498e07c62e0" />
<br><br>
<img width="861" height="582" alt="svgmap-events" src="https://github.com/user-attachments/assets/2f743e23-e086-467a-b6fe-bd95e14af6c0" />

# My solution
- Instead of attaching event listeners to `<path>` element, only attach event listeners on `this.mapImage`
- Don't attach event listener on `document`
- Use `{ once: true }` for `_clickTooltipOutsideHandler()` and deattach it in `hideTooltip()`


Tested on desktop and mobile with this config. Not sure whether it causes bug with other features or not, so please help me test it. Thanks.

```js
{
    hideFlag: true,
    colorNoData: '#FFFFFF',
    colorMin: '#FF0000',
    colorMax: '#C60000',
    initialZoom: 1,
    showZoomReset: false,
    resetZoomOnResize: false,
    allowInteraction: false,
};
```